### PR TITLE
[type-puzzle] improve CSRF helper

### DIFF
--- a/components/TypeScriptEditor.tsx
+++ b/components/TypeScriptEditor.tsx
@@ -12,6 +12,7 @@ import MonacoEditor from '@monaco-editor/react';
 import React from 'react';
 import { useState, useEffect } from 'react';
 import { useTypeChecker } from '../hooks/useTypeChecker';
+import { getCsrfToken } from '../src/utils/csrf';
 
 export const TypeScriptEditor = () => {
   const [code, setCode] = useState<string>(`type User = ???;\nconst u: User = { name: "Taro", age: 20 };`);
@@ -20,16 +21,12 @@ export const TypeScriptEditor = () => {
 
   useEffect(() => {
     // ページロード時にCookieを確認
-    const checkCookies = () => {
-      const cookies = document.cookie.split(';').map(cookie => cookie.trim());
-      // CSRFトークンが存在しない場合はエラーメッセージを表示
-      if (!cookies.some(cookie => cookie.startsWith('csrf-token='))) {
-        setCsrfError('CSRFトークンが見つかりません。ページを手動で再読み込みしてください。');
-      } else {
-        setCsrfError(null);
-      }
-    };
-    checkCookies();
+    const token = getCsrfToken();
+    if (!token) {
+      setCsrfError('CSRFトークンが見つかりません。ページを手動で再読み込みしてください。');
+    } else {
+      setCsrfError(null);
+    }
   }, []);
 
   const handleEditorChange = (value: string | undefined) => {

--- a/hooks/useTypeChecker.ts
+++ b/hooks/useTypeChecker.ts
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useErrorToast } from '../src/hooks/useErrorToast';
 import { TypeCheckRequestSchema, TypeCheckResponseSchema } from '../types/validation';
+import { getCsrfToken } from '../src/utils/csrf';
 
 type TypeCheckResult = {
   success: boolean;
@@ -21,14 +22,11 @@ export const useTypeChecker = () => {
       }
 
       // CSRFトークンの取得
-      const cookies = document.cookie.split(';');
-      const csrfCookie = cookies.find(cookie => cookie.trim().startsWith('csrf-token='));
-      if (!csrfCookie) {
+      const csrfToken = getCsrfToken();
+      if (!csrfToken) {
         setResult({ success: false, message: '❌ エラー: CSRFトークンが見つかりません。ページを再読み込みしてください。' });
         return;
       }
-
-      const csrfToken = csrfCookie.split('=')[1].trim();
 
       const res = await fetch('/api/typecheck', {
         method: 'POST',

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect } from "react";
-import Editor from "@monaco-editor/react";
-import { useErrorToast } from "../hooks/useErrorToast";
+import { useState, useEffect } from 'react';
+import Editor from '@monaco-editor/react';
+import { useErrorToast } from '../hooks/useErrorToast';
+import { getCsrfToken } from '../utils/csrf';
 
 export default function CodeEditor() {
   const [code, setCode] = useState<string>("");
@@ -9,15 +10,10 @@ export default function CodeEditor() {
 
   useEffect(() => {
     // ページロード時にCSRFトークンを取得
-    const getCsrfToken = () => {
-      const cookies = document.cookie.split(';');
-      const csrfCookie = cookies.find(cookie => cookie.trim().startsWith('csrf-token='));
-      if (csrfCookie) {
-        const token = csrfCookie.split('=')[1];
-        setCsrfToken(token);
-      }
-    };
-    getCsrfToken();
+    const token = getCsrfToken();
+    if (token) {
+      setCsrfToken(token);
+    }
   }, []);
 
   const handleTypeCheck = async () => {

--- a/src/utils/csrf.test.ts
+++ b/src/utils/csrf.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { getCsrfToken } from './csrf';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getCsrfToken', () => {
+  it('returns token when cookie exists', () => {
+    vi.stubGlobal('document', { cookie: 'foo=bar; csrf-token=test; bar=baz' });
+    expect(getCsrfToken()).toBe('test');
+  });
+
+  it('returns null when token is missing', () => {
+    vi.stubGlobal('document', { cookie: 'foo=bar' });
+    expect(getCsrfToken()).toBeNull();
+  });
+
+  it('returns null when document is undefined', () => {
+    vi.stubGlobal('document', undefined);
+    expect(getCsrfToken()).toBeNull();
+  });
+});

--- a/src/utils/csrf.ts
+++ b/src/utils/csrf.ts
@@ -1,0 +1,10 @@
+export const getCsrfToken = (): string | null => {
+  if (typeof document === 'undefined' || !document.cookie) {
+    return null;
+  }
+  const cookie = document.cookie
+    .split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith('csrf-token='));
+  return cookie ? cookie.split('=')[1] : null;
+};


### PR DESCRIPTION
## Summary
- handle missing `document` in `getCsrfToken`
- add unit test for undefined `document`

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: next not found)*
- `npm ls next` *(shows package not installed)*