### PR TITLE
[type-puzzle] prevent any usage in typecheck

### DIFF
--- a/pages/api/typecheck.test.ts
+++ b/pages/api/typecheck.test.ts
@@ -1,0 +1,25 @@
+import handler from './typecheck';
+import { describe, it, expect, vi } from 'vitest';
+
+const createMockReqRes = (code: string) => {
+  const req = {
+    method: 'POST',
+    body: { code },
+    headers: { 'x-csrf-token': 'token' },
+    cookies: { 'csrf-token': 'token' },
+  } as any;
+
+  const json = vi.fn();
+  const status = vi.fn(() => ({ json }));
+  const res = { status } as any;
+  return { req, res, json, status };
+};
+
+describe('typecheck API', () => {
+  it('rejects code containing any', async () => {
+    const { req, res, json, status } = createMockReqRes('type Foo = any');
+    await handler(req, res);
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({ error: 'anyは使用できません' });
+  });
+});

--- a/pages/api/typecheck.ts
+++ b/pages/api/typecheck.ts
@@ -43,6 +43,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     const { code } = validationResult.data;
+
+    if (/\bany\b/.test(code)) {
+      res.status(400).json({ error: 'anyは使用できません' });
+      return;
+    }
     const fileName = 'index.ts';
     const libFileName = 'lib.d.ts';
 


### PR DESCRIPTION
## Summary
- reject `any` usage in the typecheck API
- add test for the new validation

## Testing
- `npm install` *(fails: connect EHOSTUNREACH)*
- `npm test` *(fails: vitest not found)*
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: next not found)*