### PR TITLE
[type-puzzle] enable vitest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,15 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Run vitest
+        run: npm test


### PR DESCRIPTION
## Summary
- run vitest as a CI job

## Testing
- `npm test` *(fails: `vitest: not found`)*
- `npm install` *(fails: EHOSTUNREACH)*