### PR TITLE
[type-puzzle] Lvページへのリンク追加と結果画面実装

### DIFF
--- a/components/TypeScriptEditor.test.tsx
+++ b/components/TypeScriptEditor.test.tsx
@@ -1,8 +1,21 @@
 import { render, screen } from '@testing-library/react';
 import { ChakraProvider } from '@chakra-ui/react';
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { TypeScriptEditor } from './TypeScriptEditor';
+
+// useRouterのモック
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    route: '/',
+    pathname: '/',
+    query: {},
+    asPath: '/',
+  }),
+}));
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <ChakraProvider>{children}</ChakraProvider>
@@ -11,7 +24,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 describe('TypeScriptEditor', () => {
   it('displays puzzle explanation', () => {
     document.cookie = 'csrf-token=test';
-    render(<TypeScriptEditor initialLevel={1} />, { wrapper });
+    render(<TypeScriptEditor />, { wrapper });
     expect(
       screen.getByText('User型はnameとageを持つオブジェクト型を完成させます。')
     ).toBeInTheDocument();

--- a/components/TypeScriptEditor.test.tsx
+++ b/components/TypeScriptEditor.test.tsx
@@ -11,11 +11,14 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 describe('TypeScriptEditor', () => {
   it('displays puzzle explanation', () => {
     document.cookie = 'csrf-token=test';
-    render(<TypeScriptEditor />, { wrapper });
+    render(<TypeScriptEditor initialLevel={1} />, { wrapper });
     expect(
       screen.getByText('User型はnameとageを持つオブジェクト型を完成させます。')
     ).toBeInTheDocument();
     expect(screen.getByText('次の問題へ')).toBeInTheDocument();
-    expect(screen.getByText('Lv1: 0 / 100')).toBeInTheDocument();
+    expect(
+      screen.getByText('TypeScript 型パズル - Lv1 (1/5)')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
         "@monaco-editor/react": "^4.6.0",
+        "framer-motion": "^12.12.1",
         "monaco-editor": "0.52.2",
         "next": "14.2.28",
         "react": "^18.2.0",
@@ -40,6 +41,9 @@
         "typescript": "^5.5.3",
         "vite": "^5.1.6",
         "vitest": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -5057,6 +5061,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.12.1.tgz",
+      "integrity": "sha512-PFw4/GCREHI2suK/NlPSUxd+x6Rkp80uQsfCRFSOQNrm5pZif7eGtmG1VaD/UF1fW9tRBy5AaS77StatB3OJDg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.12.1",
+        "motion-utils": "^12.12.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/framesync": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.1.2.tgz",
@@ -6532,6 +6563,21 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.12.1.tgz",
+      "integrity": "sha512-GXq/uUbZBEiFFE+K1Z/sxdPdadMdfJ/jmBALDfIuHGi0NmtealLOfH9FqT+6aNPgVx8ilq0DtYmyQlo6Uj9LKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.12.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.12.1.tgz",
+      "integrity": "sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@monaco-editor/react": "^4.6.0",
+    "framer-motion": "^12.12.1",
     "monaco-editor": "0.52.2",
     "next": "14.2.28",
     "react": "^18.2.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,7 +15,9 @@ export default function Home() {
         </Heading>
         <List spacing={1}>
           {puzzlesData.levels.map((l) => (
-            <ListItem key={l.level}>Lv{l.level}</ListItem>
+            <ListItem key={l.level}>
+              <Link href={`/play?level=${l.level}`}>Lv{l.level}</Link>
+            </ListItem>
           ))}
         </List>
       </Box>

--- a/pages/play.tsx
+++ b/pages/play.tsx
@@ -1,5 +1,11 @@
 import { TypeScriptEditor } from '../components/TypeScriptEditor';
+import { useRouter } from 'next/router';
 
 export default function PlayPage() {
-  return <TypeScriptEditor />;
+  const router = useRouter();
+  if (!router.isReady) return null;
+  const levelParam = router.query.level;
+  const level = typeof levelParam === 'string' ? parseInt(levelParam, 10) : 1;
+  const initialLevel = Number.isNaN(level) ? 1 : level;
+  return <TypeScriptEditor initialLevel={initialLevel} />;
 }

--- a/pages/result.tsx
+++ b/pages/result.tsx
@@ -1,0 +1,29 @@
+import { Box, Button, Container, Heading, List, ListItem, Text } from '@chakra-ui/react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+export default function ResultPage() {
+  const router = useRouter();
+  const scoresParam = router.query.scores;
+  const scores = typeof scoresParam === 'string' ? scoresParam.split('-').map((s) => parseInt(s, 10)) : [];
+  const total = scores.reduce((sum, s) => sum + (Number.isNaN(s) ? 0 : s), 0);
+
+  return (
+    <Container maxW="container.md" py={8}>
+      <Heading size="lg" mb={4}>
+        結果
+      </Heading>
+      <Box mb={4}>
+        <List spacing={1}>
+          {scores.map((s, i) => (
+            <ListItem key={i}>Lv{i + 1}: {s} / 100</ListItem>
+          ))}
+        </List>
+      </Box>
+      <Text fontSize="lg" mb={4}>合計: {total} 点</Text>
+      <Link href="/" passHref>
+        <Button colorScheme="teal">TOPへ戻る</Button>
+      </Link>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- ホームのレベル一覧から各Lvページへ遷移できるリンクを追加
- playページで`level`クエリを読み取り初期レベルを指定
- テスト進捗を示すプログレスバーを表示し、Monacoの`;`警告を非表示
- 全レベル終了後にスコアを表示するリザルトページへ遷移
- 既存テストを新UIに合わせて更新

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*