### PR TITLE
[type-puzzle] レベル結果画面の追加とレイアウト更新

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,10 @@
+import { Box, Text } from '@chakra-ui/react';
+import React from 'react';
+
+const Footer = (): JSX.Element => (
+  <Box as="footer" bg="gray.100" py={2} textAlign="center">
+    <Text fontSize="sm">© 2023 Type Puzzle</Text>
+  </Box>
+);
+
+export default Footer;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,13 @@
+import { Box, Heading } from '@chakra-ui/react';
+import Link from 'next/link';
+import React from 'react';
+
+const Header = (): JSX.Element => (
+  <Box as="header" bg="teal.500" color="white" py={2} px={4}>
+    <Heading size="md">
+      <Link href="/">Type Puzzle</Link>
+    </Heading>
+  </Box>
+);
+
+export default Header;

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,18 @@
+import { Box } from '@chakra-ui/react';
+import React, { ReactNode } from 'react';
+import Header from './Header';
+import Footer from './Footer';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+export const Layout = ({ children }: LayoutProps): JSX.Element => (
+  <Box minH="100vh" display="flex" flexDirection="column">
+    <Header />
+    <Box as="main" flex="1">
+      {children}
+    </Box>
+    <Footer />
+  </Box>
+);

--- a/components/TypeScriptEditor.tsx
+++ b/components/TypeScriptEditor.tsx
@@ -25,9 +25,13 @@ import { useRouter } from 'next/router';
 
 interface EditorProps {
   initialLevel?: number;
+  initialScores?: number[];
 }
 
-export const TypeScriptEditor = ({ initialLevel = 1 }: EditorProps) => {
+export const TypeScriptEditor = ({
+  initialLevel = 1,
+  initialScores,
+}: EditorProps): JSX.Element => {
   const [levelIndex, setLevelIndex] = useState(initialLevel - 1);
   const [puzzleIndex, setPuzzleIndex] = useState(0);
   const [code, setCode] = useState<string>(levels[initialLevel - 1].puzzles[0].code);
@@ -35,7 +39,7 @@ export const TypeScriptEditor = ({ initialLevel = 1 }: EditorProps) => {
   const { result, checkType } = useTypeChecker();
   const [csrfError, setCsrfError] = useState<string | null>(null);
   const [scores, setScores] = useState<number[]>(
-    new Array(levels.length).fill(0)
+    initialScores ?? new Array(levels.length).fill(0)
   );
   const monaco = useMonaco();
   const router = useRouter();
@@ -52,8 +56,10 @@ export const TypeScriptEditor = ({ initialLevel = 1 }: EditorProps) => {
     if (puzzleIndex < levels[levelIndex].puzzles.length - 1) {
       setPuzzleIndex((p) => p + 1);
     } else if (levelIndex < levels.length - 1) {
-      setLevelIndex((l) => l + 1);
-      setPuzzleIndex(0);
+      router.push({
+        pathname: '/result',
+        query: { scores: scores.join('-'), level: levelIndex + 1 },
+      });
     } else {
       setFinished(true);
     }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,13 @@
 import { ChakraProvider } from '@chakra-ui/react';
 import type { AppProps } from 'next/app';
+import { Layout } from '../components/Layout';
 
-function MyApp({ Component, pageProps }: AppProps) {
+function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   return (
     <ChakraProvider resetCSS>
-      <Component {...pageProps} />
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
     </ChakraProvider>
   );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,16 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+import React from 'react';
+
+export default function Document(): JSX.Element {
+  return (
+    <Html lang="ja">
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/pages/play.tsx
+++ b/pages/play.tsx
@@ -1,11 +1,21 @@
 import { TypeScriptEditor } from '../components/TypeScriptEditor';
 import { useRouter } from 'next/router';
 
-export default function PlayPage() {
+export default function PlayPage(): JSX.Element | null {
   const router = useRouter();
   if (!router.isReady) return null;
   const levelParam = router.query.level;
+  const scoresParam = router.query.scores;
   const level = typeof levelParam === 'string' ? parseInt(levelParam, 10) : 1;
   const initialLevel = Number.isNaN(level) ? 1 : level;
-  return <TypeScriptEditor initialLevel={initialLevel} />;
+  const initialScores =
+    typeof scoresParam === 'string'
+      ? scoresParam.split('-').map((s) => parseInt(s, 10))
+      : undefined;
+  return (
+    <TypeScriptEditor
+      initialLevel={initialLevel}
+      initialScores={initialScores}
+    />
+  );
 }

--- a/pages/result.tsx
+++ b/pages/result.tsx
@@ -1,18 +1,50 @@
-import { Box, Button, Container, Heading, List, ListItem, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  Container,
+  Heading,
+  List,
+  ListItem,
+  Text,
+} from '@chakra-ui/react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import puzzlesData from '../data/puzzles.json';
+import { useScoreAnimation } from '../src/hooks/useScoreAnimation';
 
-export default function ResultPage() {
+export default function ResultPage(): JSX.Element {
   const router = useRouter();
   const scoresParam = router.query.scores;
-  const scores = typeof scoresParam === 'string' ? scoresParam.split('-').map((s) => parseInt(s, 10)) : [];
+  const levelParam = router.query.level;
+  const scores =
+    typeof scoresParam === 'string'
+      ? scoresParam.split('-').map((s) => parseInt(s, 10))
+      : [];
+  const level =
+    typeof levelParam === 'string' ? parseInt(levelParam, 10) : null;
   const total = scores.reduce((sum, s) => sum + (Number.isNaN(s) ? 0 : s), 0);
+  const finalScore = level ? scores[level - 1] ?? 0 : total;
+  const animatedScore = useScoreAnimation(finalScore);
+
+  const handleNext = (): void => {
+    if (level && level < puzzlesData.levels.length) {
+      router.push({
+        pathname: '/play',
+        query: { level: level + 1, scores: scores.join('-') },
+      });
+    } else {
+      router.push('/');
+    }
+  };
 
   return (
-    <Container maxW="container.md" py={8}>
-      <Heading size="lg" mb={4}>
-        結果
+    <Container maxW={{ base: 'container.sm', md: 'container.md' }} py={8}>
+      <Heading size="lg" mb={4} textAlign="center">
+        {level ? `Lv${level} 結果` : '結果'}
       </Heading>
+      <Text fontSize="4xl" fontWeight="bold" mb={4} textAlign="center">
+        {animatedScore} / 100
+      </Text>
       <Box mb={4}>
         <List spacing={1}>
           {scores.map((s, i) => (
@@ -20,10 +52,10 @@ export default function ResultPage() {
           ))}
         </List>
       </Box>
-      <Text fontSize="lg" mb={4}>合計: {total} 点</Text>
-      <Link href="/" passHref>
-        <Button colorScheme="teal">TOPへ戻る</Button>
-      </Link>
+      {!level && <Text fontSize="lg" mb={4}>合計: {total} 点</Text>}
+      <Button colorScheme="teal" onClick={handleNext}>
+        {level && level < puzzlesData.levels.length ? '次のレベルへ' : 'TOPへ戻る'}
+      </Button>
     </Container>
   );
 }

--- a/src/hooks/useScoreAnimation.test.tsx
+++ b/src/hooks/useScoreAnimation.test.tsx
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useScoreAnimation } from './useScoreAnimation';
+
+describe('useScoreAnimation', () => {
+  it('returns final score after duration', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useScoreAnimation(50, 1000));
+    vi.advanceTimersByTime(1000);
+    expect(result.current).toBe(50);
+    vi.useRealTimers();
+  });
+});

--- a/src/hooks/useScoreAnimation.ts
+++ b/src/hooks/useScoreAnimation.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+export const useScoreAnimation = (
+  finalScore: number,
+  duration = 3000,
+): number => {
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    const start = Date.now();
+    const interval = setInterval(() => {
+      const elapsed = Date.now() - start;
+      if (elapsed >= duration) {
+        clearInterval(interval);
+        setScore(finalScore);
+      } else {
+        setScore(Math.floor(Math.random() * 101));
+      }
+    }, 100);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [finalScore, duration]);
+
+  return score;
+};


### PR DESCRIPTION
## 概要（日本語）

- 各レベル完了後に結果画面へ遷移するよう `TypeScriptEditor` を改修
- 結果画面ではスコアを3秒間ランダム表示する `useScoreAnimation` を追加
- ヘッダー・フッターを備えた `Layout` を作成し全ページに適用
- スマートフォン対応のため `_document` に viewport を追加

---

## QA確認したこと（ローカルでの確認）

- [ ] 型エラーが発生しないこと（VSCode上で確認）
- [ ] `package.json` に必要な依存が追加されていること
- [ ] 出力された設定ファイルが意図通りであること
- [ ] **ビルド・テストは実行していません（Codex制約上）**

### lint / test
```
$ npm run lint
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js'
$ npm test
sh: 1: vitest: not found
```

---

## レビューアーに確認して欲しいこと

- [ ] 型定義が適切か
- [ ] 不要なコードが含まれていないか
- [ ] Codexの制約に従っているか

---

## その他（Codexへの補足：自動生成系）

- 実行不可能な処理は含まれていません
- 関数レベルのロジックのみを中心に変更しています
