### PR TITLE
[type-puzzle] Keep progress via cookies

### DIFF
--- a/components/TypeScriptEditor.tsx
+++ b/components/TypeScriptEditor.tsx
@@ -21,7 +21,7 @@ type Puzzles = typeof puzzlesData.levels;
 
 const levels: Puzzles = puzzlesData.levels;
 import { getCsrfToken } from '../src/utils/csrf';
-import { setScores, setLevel } from '../src/utils/progress';
+import { setLevel } from '../src/utils/progress';
 
 import { useRouter } from 'next/router';
 

--- a/components/TypeScriptEditor.tsx
+++ b/components/TypeScriptEditor.tsx
@@ -21,6 +21,7 @@ type Puzzles = typeof puzzlesData.levels;
 
 const levels: Puzzles = puzzlesData.levels;
 import { getCsrfToken } from '../src/utils/csrf';
+import { setScores, setLevel } from '../src/utils/progress';
 
 import { useRouter } from 'next/router';
 
@@ -57,18 +58,21 @@ export const TypeScriptEditor = ({
     if (puzzleIndex < levels[levelIndex].puzzles.length - 1) {
       setPuzzleIndex((p) => p + 1);
     } else if (levelIndex < levels.length - 1) {
-      router.push({
-        pathname: '/result',
-        query: { scores: scores.join('-'), level: levelIndex + 1 },
-      });
+      setScores(scores);
+      setLevel(levelIndex + 1);
+      router.push('/result');
     } else {
+      setScores(scores);
+      setLevel(null);
       setFinished(true);
     }
   };
 
   useEffect(() => {
     if (finished) {
-      router.push({ pathname: '/result', query: { scores: scores.join('-') } });
+      setScores(scores);
+      setLevel(null);
+      router.push('/result');
     }
   }, [finished, router, scores]);
 

--- a/pages/play.tsx
+++ b/pages/play.tsx
@@ -2,18 +2,37 @@ import React from 'react';
 import type { JSX } from 'react';
 import { TypeScriptEditor } from '../components/TypeScriptEditor';
 import { useRouter } from 'next/router';
+import {
+  getLevel,
+  getScores,
+  setLevel,
+  setScores,
+} from '../src/utils/progress';
 
 export default function PlayPage(): JSX.Element | null {
   const router = useRouter();
   if (!router.isReady) return null;
   const levelParam = router.query.level;
   const scoresParam = router.query.scores;
-  const level = typeof levelParam === 'string' ? parseInt(levelParam, 10) : 1;
+  const cookieLevel = getLevel();
+  const cookieScores = getScores();
+
+  const level =
+    typeof levelParam === 'string'
+      ? parseInt(levelParam, 10)
+      : cookieLevel ?? 1;
+
   const initialLevel = Number.isNaN(level) ? 1 : level;
+
   const initialScores =
     typeof scoresParam === 'string'
       ? scoresParam.split('-').map((s) => parseInt(s, 10))
-      : undefined;
+      : cookieScores ?? undefined;
+
+  setLevel(initialLevel);
+  if (initialScores) {
+    setScores(initialScores);
+  }
   return (
     <TypeScriptEditor
       initialLevel={initialLevel}

--- a/pages/result.tsx
+++ b/pages/result.tsx
@@ -12,28 +12,44 @@ import {
 import { useRouter } from 'next/router';
 import puzzlesData from '../data/puzzles.json';
 import { useScoreAnimation } from '../src/hooks/useScoreAnimation';
+import {
+  getLevel,
+  getScores,
+  setLevel,
+  setScores,
+} from '../src/utils/progress';
 
 export default function ResultPage(): JSX.Element {
   const router = useRouter();
   const scoresParam = router.query.scores;
   const levelParam = router.query.level;
+  const cookieScores = getScores() ?? [];
+  const cookieLevel = getLevel();
   const scores =
     typeof scoresParam === 'string'
       ? scoresParam.split('-').map((s) => parseInt(s, 10))
-      : [];
+      : cookieScores;
   const level =
-    typeof levelParam === 'string' ? parseInt(levelParam, 10) : null;
+    typeof levelParam === 'string'
+      ? parseInt(levelParam, 10)
+      : cookieLevel;
   const total = scores.reduce((sum, s) => sum + (Number.isNaN(s) ? 0 : s), 0);
   const finalScore = level ? scores[level - 1] ?? 0 : total;
   const animatedScore = useScoreAnimation(finalScore);
 
+  React.useEffect(() => {
+    setScores(scores);
+    setLevel(level ?? null);
+  }, [scores, level]);
+
   const handleNext = (): void => {
     if (level && level < puzzlesData.levels.length) {
-      router.push({
-        pathname: '/play',
-        query: { level: level + 1, scores: scores.join('-') },
-      });
+      setScores(scores);
+      setLevel(level + 1);
+      router.push('/play');
     } else {
+      setScores(scores);
+      setLevel(null);
       router.push('/');
     }
   };

--- a/src/utils/progress.test.ts
+++ b/src/utils/progress.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getScores, setScores, getLevel, setLevel } from './progress';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('progress utils', () => {
+  it('reads and writes scores', () => {
+    vi.stubGlobal('document', { cookie: '' });
+    setScores([10, 20]);
+    expect(document.cookie).toContain('scores=10-20');
+    vi.stubGlobal('document', { cookie: 'scores=10-20' });
+    expect(getScores()).toEqual([10, 20]);
+  });
+
+  it('reads and writes level', () => {
+    vi.stubGlobal('document', { cookie: '' });
+    setLevel(2);
+    expect(document.cookie).toContain('level=2');
+    vi.stubGlobal('document', { cookie: 'level=2' });
+    expect(getLevel()).toBe(2);
+  });
+
+  it('handles missing cookie', () => {
+    vi.stubGlobal('document', { cookie: '' });
+    expect(getScores()).toBeNull();
+    expect(getLevel()).toBeNull();
+  });
+});

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -1,0 +1,43 @@
+export const getScores = (): number[] | null => {
+  if (typeof document === 'undefined' || !document.cookie) {
+    return null;
+  }
+  const cookie = document.cookie
+    .split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith('scores='));
+  return cookie ? cookie.split('=')[1].split('-').map((s) => parseInt(s, 10)) : null;
+};
+
+export const setScores = (scores: number[]): void => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  document.cookie = `scores=${scores.join('-')}; path=/`;
+};
+
+export const getLevel = (): number | null => {
+  if (typeof document === 'undefined' || !document.cookie) {
+    return null;
+  }
+  const cookie = document.cookie
+    .split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith('level='));
+  if (!cookie) {
+    return null;
+  }
+  const level = parseInt(cookie.split('=')[1], 10);
+  return Number.isNaN(level) ? null : level;
+};
+
+export const setLevel = (level: number | null): void => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  if (level === null) {
+    document.cookie = 'level=; path=/; max-age=0';
+  } else {
+    document.cookie = `level=${level}; path=/`;
+  }
+};


### PR DESCRIPTION
## 概要（日本語）

- プレイ状態（レベル・スコア）の保持をクエリパラメータから Cookie へ変更しました
- Cookie 操作用のユーティリティ `progress.ts` を追加しテストを作成しました
- `TypeScriptEditor` 及び `result`/`play` ページを Cookie 読み書きに対応

---

## QA確認したこと（ローカルでの確認）

- [ ] 型エラーが発生しないこと（VSCode上で確認）
- [ ] `package.json` に必要な依存が追加されていること
- [ ] 出力された設定ファイル（例: `.eslintrc.js`, `tsconfig.json`）が意図通りであること
- [ ] **ビルド・テストは実行していません（Codex制約上）**

---

## レビューアーに確認して欲しいこと

- [ ] 型定義の設計が妥当か（過剰なジェネリクスや冗長な型でないか）
- [ ] 不要なコード・依存が含まれていないか
- [ ] コード品質（関数の粒度、コメント、再利用性）
- [ ] Codexの制約に従っているか（`npm install`や外部アクセスが含まれていない）

---

## その他（Codexへの補足：自動生成系）

- 実行不可能な処理（`npx`, `next build`, `vitest`）は含まれていません
- 設定ファイルの出力や関数レベルのロジックのみを含んでいます
- 外部APIアクセス、実行依存のあるコードは避けています