### PR TITLE
[type-puzzle] CSRF middleware on play pages

### DIFF
--- a/middleware.test.ts
+++ b/middleware.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { config } from './middleware';
+
+describe('middleware config', () => {
+  it('includes pages in matcher', () => {
+    expect(config.matcher).toEqual(
+      expect.arrayContaining(['/play', '/result'])
+    );
+  });
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -36,5 +36,7 @@ export const config = {
   matcher: [
     '/api/:path*',
     '/', // トップページにもミドルウェアを適用
+    '/play', // レベル選択ページ用
+    '/result', // 結果表示ページ用
   ],
-}; 
+};


### PR DESCRIPTION
## 概要（日本語）

- ミドルウェアの `matcher` に `/play` と `/result` を追加し、直接ページ遷移した際にも CSRF トークンが付与されるよう修正
- 追加したページパスを検証する `middleware.test.ts` を作成

---

## QA確認したこと（ローカルでの確認）

- [ ] 型エラーが発生しないこと（VSCode上で確認）
- [ ] `package.json` に必要な依存が追加されていること
- [ ] 出力された設定ファイル（例: `.eslintrc.js`, `tsconfig.json`）が意図通りであること
- [ ] **ビルド・テストは実行していません（Codex制約上）**

---

## レビューアーに確認して欲しいこと

- [ ] CSRF トークン付与ページの範囲が妥当か
- [ ] 追加テストの内容が適切か
- [ ] 不要なコード・依存が含まれていないか
- [ ] Codex の制約に従っているか

---

## その他（Codexへの補足：自動生成系）

- 実行不可能な処理（`npx`, `next build`, `vitest`）は含まれていません
- 設定ファイルの出力や関数レベルのロジックのみを含んでいます