### PR TITLE
[type-puzzle] interfaceとtypeの分割

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,12 +1,9 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import type { JSX } from 'react';
 import { Box } from '@chakra-ui/react';
 import Header from './Header';
 import Footer from './Footer';
-
-interface LayoutProps {
-  children: ReactNode;
-}
+import type { LayoutProps } from '../types/components';
 
 export const Layout = ({ children }: LayoutProps): JSX.Element => (
   <Box minH="100vh" display="flex" flexDirection="column">

--- a/components/TypeScriptEditor.tsx
+++ b/components/TypeScriptEditor.tsx
@@ -24,11 +24,7 @@ import { getCsrfToken } from '../src/utils/csrf';
 import { setLevel } from '../src/utils/progress';
 
 import { useRouter } from 'next/router';
-
-interface EditorProps {
-  initialLevel?: number;
-  initialScores?: number[];
-}
+import type { EditorProps } from '../types/components';
 
 export const TypeScriptEditor = ({
   initialLevel = 1,

--- a/hooks/useTypeChecker.ts
+++ b/hooks/useTypeChecker.ts
@@ -2,11 +2,7 @@ import { useState } from 'react';
 import { useErrorToast } from '../src/hooks/useErrorToast';
 import { TypeCheckRequestSchema, TypeCheckResponseSchema } from '../types/validation';
 import { getCsrfToken } from '../src/utils/csrf';
-
-type TypeCheckResult = {
-  success: boolean;
-  message: string;
-};
+import type { TypeCheckResult } from '../types/typecheck';
 
 export const useTypeChecker = () => {
   const [result, setResult] = useState<TypeCheckResult | null>(null);

--- a/types/components.ts
+++ b/types/components.ts
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+
+export interface LayoutProps {
+  children: ReactNode;
+}
+
+export interface EditorProps {
+  initialLevel?: number;
+  initialScores?: number[];
+}

--- a/types/typecheck.ts
+++ b/types/typecheck.ts
@@ -1,0 +1,4 @@
+export type TypeCheckResult = {
+  success: boolean;
+  message: string;
+};


### PR DESCRIPTION
## 概要（日本語）

このPRでは、以下の対応を行いました：

- componentsとhooksの型定義を`types`ディレクトリへ移動しました
- 各ファイルは共通の型ファイルから型をインポートするように修正しました

---

## QA確認したこと（ローカルでの確認）

- [ ] 型エラーが発生しないこと（VSCode上で確認）
- [ ] `package.json` に必要な依存が追加されていること
- [ ] 出力された設定ファイル（例: `.eslintrc.js`, `tsconfig.json`）が意図通りであること
- [x] **ビルド・テストは実行していません（Codex制約上）**

---

## レビューアーに確認して欲しいこと

- [ ] 型定義の設計が妥当か（過剰なジェネリクスや冗長な型でないか）
- [ ] 不要なコード・依存が含まれていないか
- [ ] コード品質（関数の粒度、コメント、再利用性）
- [ ] Codexの制約に従っているか（`npm install`や外部アクセスが含まれていない）

---

## その他（Codexへの補足：自動生成系）

- 実行不可能な処理（`npx`, `next build`, `vitest`）は含まれていません
- 設定ファイルの出力や関数レベルのロジックのみを含んでいます
- 外部APIアクセス、実行依存のあるコードは避けています
