### PR TITLE
[type-puzzle] Fix viewport meta warning

### DIFF
--- a/pages/_app.test.tsx
+++ b/pages/_app.test.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import MyApp from './_app';
+
+const Dummy = (): JSX.Element => <div>dummy</div>;
+
+describe('MyApp', () => {
+  it('adds viewport meta tag', () => {
+    render(<MyApp Component={Dummy} pageProps={{}} />);
+    const meta = document.querySelector('meta[name="viewport"]');
+    expect(meta).not.toBeNull();
+    expect(meta?.getAttribute('content')).toBe(
+      'width=device-width, initial-scale=1'
+    );
+  });
+});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 import type { JSX } from 'react';
 import { ChakraProvider } from '@chakra-ui/react';
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 import { Layout } from '../components/Layout';
 
 function MyApp({ Component, pageProps }: AppProps): JSX.Element {
   return (
     <ChakraProvider resetCSS>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
       <Layout>
         <Component {...pageProps} />
       </Layout>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,9 +5,7 @@ import { Html, Head, Main, NextScript } from 'next/document';
 export default function Document(): JSX.Element {
   return (
     <Html lang="ja">
-      <Head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </Head>
+      <Head />
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
## 概要（日本語）

このPRでは、Next.js の警告 `no-document-viewport-meta` に対応しました。

- `_document.tsx` から viewport メタタグを削除
- `_app.tsx` 側で `<Head>` に viewport メタタグを追加
- `_app.test.tsx` を追加し、meta タグの存在を確認するテストを作成

---

## QA確認したこと（ローカルでの確認）

- [ ] 型エラーが発生しないこと（VSCode上で確認）
- [ ] `package.json` に必要な依存が追加されていること
- [ ] 出力された設定ファイル（例: `.eslintrc.js`, `tsconfig.json`）が意図通りであること
- [ ] **ビルド・テストは実行していません（Codex制約上）**

---

## レビューアーに確認して欲しいこと

- [ ] 型定義の設計が妥当か
- [ ] 不要なコード・依存が含まれていないか
- [ ] コード品質（関数の粒度、コメント、再利用性）
- [ ] Codexの制約に従っているか

---

## その他（Codexへの補足：自動生成系）

- 実行不可能な処理（`npx`, `next build`, `vitest`）は含まれていません
- 設定ファイルの出力や関数レベルのロジックのみを含んでいます