### PR TITLE
[type-puzzle] Replace JSX with React element in test

### DIFF
--- a/pages/_app.test.tsx
+++ b/pages/_app.test.tsx
@@ -1,12 +1,15 @@
 import { render } from '@testing-library/react';
-import React from 'react';
+import React, { ReactElement } from 'react';
+import { describe, it, expect } from 'vitest';
 import MyApp from './_app';
 
-const Dummy = (): JSX.Element => <div>dummy</div>;
+const Dummy = (): ReactElement => React.createElement('div', null, 'dummy');
 
 describe('MyApp', () => {
   it('adds viewport meta tag', () => {
-    render(<MyApp Component={Dummy} pageProps={{}} />);
+    render(
+      React.createElement(MyApp, { Component: Dummy, pageProps: {} })
+    );
     const meta = document.querySelector('meta[name="viewport"]');
     expect(meta).not.toBeNull();
     expect(meta?.getAttribute('content')).toBe(


### PR DESCRIPTION
## 概要（日本語）

- `pages/_app.test.tsx` の JSX を `React.createElement` に置き換え、`vitest` のグローバル関数をインポート

---

## QA確認したこと（ローカルでの確認）

- [ ] 型エラーが発生しないこと（VSCode上で確認）
- [ ] `package.json` に必要な依存が追加されていること
- [ ] 出力された設定ファイル（例: `.eslintrc.js`, `tsconfig.json`）が意図通りであること
- [ ] **ビルド・テストは実行していません（Codex制約上）**

---

## レビューアーに確認して欲しいこと

- [ ] 型定義の設計が妥当か（過剰なジェネリクスや冗長な型でないか）
- [ ] 不要なコード・依存が含まれていないか
- [ ] コード品質（関数の粒度、コメント、再利用性）
- [ ] Codexの制約に従っているか（`npm install`や外部アクセスが含まれていない）

---

## その他（Codexへの補足：自動生成系）

- 実行不可能な処理（`npx`, `next build`, `vitest`）は含まれていません
- 設定ファイルの出力や関数レベルのロジックのみを含んでいます
- 外部APIアクセス、実行依存のあるコードは避けています