### PR TITLE
[type-puzzle] React import cleanup

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,8 +1,6 @@
-import React from 'react';
-import type { JSX } from 'react';
 import { Box, Text } from '@chakra-ui/react';
 
-const Footer = (): JSX.Element => (
+const Footer = () => (
   <Box as="footer" bg="gray.100" py={2} textAlign="center">
     <Text fontSize="sm">© 2025 Type Puzzle</Text>
   </Box>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,9 +1,7 @@
-import React from 'react';
-import type { JSX } from 'react';
 import { Box, Heading } from '@chakra-ui/react';
 import Link from 'next/link';
 
-const Header = (): JSX.Element => (
+const Header = () => (
   <Box as="header" bg="teal.500" color="white" py={2} px={4}>
     <Heading size="md">
       <Link href="/">Type Puzzle</Link>

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,11 +1,9 @@
-import React from 'react';
-import type { JSX } from 'react';
 import { Box } from '@chakra-ui/react';
 import Header from './Header';
 import Footer from './Footer';
 import type { LayoutProps } from '../types/components';
 
-export const Layout = ({ children }: LayoutProps): JSX.Element => (
+export const Layout = ({ children }: LayoutProps) => (
   <Box minH="100vh" display="flex" flexDirection="column">
     <Header />
     <Box as="main" flex="1">

--- a/components/TypeScriptEditor.test.tsx
+++ b/components/TypeScriptEditor.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { ChakraProvider } from '@chakra-ui/react';
-import React from 'react';
+import type { ReactNode } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { TypeScriptEditor } from './TypeScriptEditor';
 
@@ -17,7 +17,7 @@ vi.mock('next/router', () => ({
   }),
 }));
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
+const wrapper = ({ children }: { children: ReactNode }) => (
   <ChakraProvider>{children}</ChakraProvider>
 );
 

--- a/components/TypeScriptEditor.tsx
+++ b/components/TypeScriptEditor.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import type { JSX } from 'react';
+
 import {
   Box,
   Button,
@@ -29,7 +28,7 @@ import type { EditorProps } from '../types/components';
 export const TypeScriptEditor = ({
   initialLevel = 1,
   initialScores,
-}: EditorProps): JSX.Element => {
+}: EditorProps) => {
   const [levelIndex] = useState(initialLevel - 1);
   const [puzzleIndex, setPuzzleIndex] = useState(0);
   const [code, setCode] = useState<string>(levels[initialLevel - 1].puzzles[0].code);

--- a/hooks/useTypeChecker.test.tsx
+++ b/hooks/useTypeChecker.test.tsx
@@ -2,9 +2,9 @@ import { renderHook, act } from '@testing-library/react';
 import { useTypeChecker } from './useTypeChecker';
 import { describe, expect, it, beforeEach, vi, beforeAll, afterAll, afterEach } from 'vitest';
 import { ChakraProvider } from '@chakra-ui/react';
-import React from 'react';
+import type { ReactNode } from 'react';
 
-const wrapper = ({ children }: { children: React.ReactNode }) => (
+const wrapper = ({ children }: { children: ReactNode }) => (
   <ChakraProvider>{children}</ChakraProvider>
 );
 

--- a/pages/_app.test.tsx
+++ b/pages/_app.test.tsx
@@ -1,15 +1,13 @@
 import { render } from '@testing-library/react';
-import React, { ReactElement } from 'react';
+import { createElement, type ReactElement } from 'react';
 import { describe, it, expect } from 'vitest';
 import MyApp from './_app';
 
-const Dummy = (): ReactElement => React.createElement('div', null, 'dummy');
+const Dummy = (): ReactElement => createElement('div', null, 'dummy');
 
 describe('MyApp', () => {
   it('adds viewport meta tag', () => {
-    render(
-      React.createElement(MyApp, { Component: Dummy, pageProps: {} })
-    );
+    render(createElement(MyApp, { Component: Dummy, pageProps: {} }));
     const meta = document.querySelector('meta[name="viewport"]');
     expect(meta).not.toBeNull();
     expect(meta?.getAttribute('content')).toBe(

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect } from 'react';
-import type { JSX } from 'react';
+import { useEffect } from 'react';
 import { ChakraProvider } from '@chakra-ui/react';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import { Layout } from '../components/Layout';
 
-function MyApp({ Component, pageProps }: AppProps): JSX.Element {
+function MyApp({ Component, pageProps }: AppProps) {
   useEffect(() => {
     const selector = 'meta[name="viewport"]';
     if (!document.querySelector(selector)) {

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,8 +1,6 @@
-import React from 'react';
-import type { JSX } from 'react';
 import { Html, Head, Main, NextScript } from 'next/document';
 
-export default function Document(): JSX.Element {
+export default function Document() {
   return (
     <Html lang="ja">
       <Head />

--- a/pages/play.tsx
+++ b/pages/play.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-import type { JSX } from 'react';
 import { TypeScriptEditor } from '../components/TypeScriptEditor';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
@@ -10,7 +8,7 @@ import {
   setScores,
 } from '../src/utils/progress';
 
-export default function PlayPage(): JSX.Element | null {
+export default function PlayPage() {
   const router = useRouter();
   if (!router.isReady) return null;
   const levelParam = router.query.level;

--- a/pages/result.tsx
+++ b/pages/result.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import type { JSX } from 'react';
+import { useEffect } from 'react';
 import {
   Box,
   Button,
@@ -20,7 +19,7 @@ import {
   setScores,
 } from '../src/utils/progress';
 
-export default function ResultPage(): JSX.Element {
+export default function ResultPage() {
   const router = useRouter();
   const scoresParam = router.query.scores;
   const levelParam = router.query.level;
@@ -38,7 +37,7 @@ export default function ResultPage(): JSX.Element {
   const finalScore = level ? scores[level - 1] ?? 0 : total;
   const animatedScore = useScoreAnimation(finalScore);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setScores(scores);
     setLevel(level ?? null);
   }, [scores, level]);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,7 +2,7 @@
 /// <reference types="jsdom" />
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
-import React from 'react';
+import * as React from 'react';
 import { JSDOM } from 'jsdom';
 
 // DOMのセットアップ


### PR DESCRIPTION
## Summary
- drop `React` default imports and `JSX.Element` annotations
- adjust hooks and tests for new imports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*