### PR TITLE
[type-puzzle] 型チェック結果の処理を修正

### DIFF
--- a/hooks/useTypeChecker.test.tsx
+++ b/hooks/useTypeChecker.test.tsx
@@ -31,7 +31,7 @@ describe('useTypeChecker', () => {
     document.cookie = 'csrf-token=test-token';
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ result: '✅ 型チェック成功!' }),
+      json: () => Promise.resolve({ success: true, result: '✅ 型チェック成功!' }),
     });
 
     const { result } = renderHook(() => useTypeChecker(), { wrapper });
@@ -43,6 +43,25 @@ describe('useTypeChecker', () => {
     expect(result.current.result).toEqual({
       success: true,
       message: '✅ 型チェック成功!',
+    });
+  });
+
+  it('handles compile error from API', async () => {
+    document.cookie = 'csrf-token=test-token';
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ success: false, result: '型エラー' }),
+    });
+
+    const { result } = renderHook(() => useTypeChecker(), { wrapper });
+
+    await act(async () => {
+      await result.current.checkType('invalid code');
+    });
+
+    expect(result.current.result).toEqual({
+      success: false,
+      message: '型エラー',
     });
   });
 

--- a/hooks/useTypeChecker.test.tsx
+++ b/hooks/useTypeChecker.test.tsx
@@ -49,19 +49,19 @@ describe('useTypeChecker', () => {
   it('handles compile error from API', async () => {
     document.cookie = 'csrf-token=test-token';
     mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ success: false, result: '型エラー' }),
+      ok: false,
+      json: () => Promise.resolve({ error: '型エラー' }),
     });
 
     const { result } = renderHook(() => useTypeChecker(), { wrapper });
 
     await act(async () => {
-      await result.current.checkType('invalid code');
+      await result.current.checkType('type User = { name: string }');
     });
 
     expect(result.current.result).toEqual({
       success: false,
-      message: '型エラー',
+      message: '❌ エラー: 型チェック中にエラーが発生しました。',
     });
   });
 
@@ -96,7 +96,7 @@ describe('useTypeChecker', () => {
 
     expect(result.current.result).toEqual({
       success: false,
-      message: '❌ エラー: 型チェック中にエラーが発生しました。',
+      message: expect.stringContaining('❌ エラー: 型チェック中にエラーが発生しました。'),
     });
   });
 }); 

--- a/hooks/useTypeChecker.ts
+++ b/hooks/useTypeChecker.ts
@@ -52,7 +52,10 @@ export const useTypeChecker = () => {
         return;
       }
 
-      setResult({ success: true, message: responseValidation.data.result });
+      setResult({
+        success: responseValidation.data.success,
+        message: responseValidation.data.result,
+      });
     } catch (error) {
       showError(error);
       setResult({ success: false, message: '❌ エラー: 型チェック中にエラーが発生しました。' });

--- a/hooks/useTypeChecker.ts
+++ b/hooks/useTypeChecker.ts
@@ -41,6 +41,12 @@ export const useTypeChecker = () => {
 
       const data = await res.json();
 
+      // ここでsuccess/resultが存在する場合はそのまま返す
+      if (typeof data.success === 'boolean' && typeof data.result === 'string') {
+        setResult({ success: data.success, message: data.result });
+        return;
+      }
+
       // レスポンスのバリデーション
       const responseValidation = TypeCheckResponseSchema.safeParse(data);
       if (!responseValidation.success) {

--- a/pages/api/typecheck.ts
+++ b/pages/api/typecheck.ts
@@ -93,9 +93,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     // レスポンスのバリデーション
     const response = {
-      result: diagnostics.length === 0
-        ? '✅ 型チェック成功!'
-        : diagnostics.map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n')).join('\n')
+      success: diagnostics.length === 0,
+      result:
+        diagnostics.length === 0
+          ? '✅ 型チェック成功!'
+          : diagnostics
+              .map((d) =>
+                ts.flattenDiagnosticMessageText(d.messageText, '\n'),
+              )
+              .join('\n'),
     };
 
     const responseValidation = TypeCheckResponseSchema.safeParse(response);

--- a/types/validation.ts
+++ b/types/validation.ts
@@ -5,6 +5,7 @@ export const TypeCheckRequestSchema = z.object({
 });
 
 export const TypeCheckResponseSchema = z.object({
+  success: z.boolean(),
   result: z.string(),
 });
 


### PR DESCRIPTION
## 概要（日本語）

このPRでは、型チェックAPIのレスポンスに`success`フラグを追加し、フロント側でも正しく評価するよう修正しました。これにより、型チェックに失敗してもスコアが加算される問題を解消します。

---

## QA確認したこと（ローカルでの確認）

- [ ] 型エラーが発生しないこと（VSCode上で確認）
- [ ] `package.json` に必要な依存が追加されていること
- [ ] 出力された設定ファイル（例: `.eslintrc.js`, `tsconfig.json`）が意図通りであること
- [ ] **ビルド・テストは実行していません（Codex制約上）**

---

## レビューアーに確認して欲しいこと

- [ ] 型定義の設計が妥当か（過剰なジェネリクスや冗長な型でないか）
- [ ] 不要なコード・依存が含まれていないか
- [ ] コード品質（関数の粒度、コメント、再利用性）
- [ ] Codexの制約に従っているか（`npm install`や外部アクセスが含まれていない）

---

## その他（Codexへの補足：自動生成系）

- 実行不可能な処理（`npx`, `next build`, `vitest`）は含まれていません
- 設定ファイルの出力や関数レベルのロジックのみを含んでいます