### PR TITLE
[type-puzzle] Reset cookie state on first puzzle

### DIFF
--- a/pages/play.tsx
+++ b/pages/play.tsx
@@ -6,6 +6,7 @@ import {
   getScores,
   setLevel,
   setScores,
+  resetProgress,
 } from '../src/utils/progress';
 
 export default function PlayPage() {
@@ -27,6 +28,10 @@ export default function PlayPage() {
     typeof scoresParam === 'string'
       ? scoresParam.split('-').map((s) => parseInt(s, 10))
       : cookieScores ?? undefined;
+
+  if (initialLevel === 1 && typeof scoresParam !== 'string') {
+    resetProgress();
+  }
 
   setLevel(initialLevel);
   if (initialScores) {

--- a/src/utils/progress.test.ts
+++ b/src/utils/progress.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getScores, setScores, getLevel, setLevel } from './progress';
+import { getScores, setScores, getLevel, setLevel, resetProgress } from './progress';
 
 beforeEach(() => {
   document.cookie = '';
@@ -31,5 +31,12 @@ describe('progress utils', () => {
     vi.stubGlobal('document', { cookie: '' });
     expect(getScores()).toBeNull();
     expect(getLevel()).toBeNull();
+  });
+
+  it('resets progress to defaults', () => {
+    vi.stubGlobal('document', { cookie: 'scores=10-20-0-0-0; level=2' });
+    resetProgress();
+    expect(document.cookie).toContain('scores=0-0-0-0-0');
+    expect(document.cookie).toContain('level=1');
   });
 });

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -65,3 +65,12 @@ export const setLevel = (level: number | null): void => {
     document.cookie = `level=${level}; path=/`;
   }
 };
+
+export const resetProgress = (): void => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const zeroScores = new Array<number>(TOTAL_LEVELS).fill(0);
+  setScores(zeroScores);
+  setLevel(1);
+};


### PR DESCRIPTION
## Summary
- add `resetProgress` utility
- reset cookies on first puzzle
- test resetting progress

## Testing
- `eslint pages/play.tsx src/utils/progress.ts src/utils/progress.test.ts` *(fails: Cannot find package '@eslint/js')*