### PR TITLE
[type-puzzle] fix progress display

### DIFF
--- a/components/TypeScriptEditor.test.tsx
+++ b/components/TypeScriptEditor.test.tsx
@@ -33,5 +33,6 @@ describe('TypeScriptEditor', () => {
       screen.getByText('TypeScript 型パズル - Lv1 (1/5)')
     ).toBeInTheDocument();
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.getByText('進捗: 1/5')).toBeInTheDocument();
   });
 });

--- a/components/TypeScriptEditor.tsx
+++ b/components/TypeScriptEditor.tsx
@@ -120,9 +120,13 @@ export const TypeScriptEditor = ({
           {levels[levelIndex].puzzles.length})
         </Heading>
         <Box>
-          <Text>進捗: {puzzleIndex}/{levels[levelIndex].puzzles.length}</Text>
+          <Text>
+            進捗: {puzzleIndex + 1}/{levels[levelIndex].puzzles.length}
+          </Text>
           <Progress
-            value={(puzzleIndex / levels[levelIndex].puzzles.length) * 100}
+            value={
+              ((puzzleIndex + 1) / levels[levelIndex].puzzles.length) * 100
+            }
             size="sm"
             mt={2}
           />


### PR DESCRIPTION
## Summary
- fix progress text to start from 1/5
- adjust progress bar calculation
- update corresponding test

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*