### PR TITLE
feat: Lv1-4 Pair を number タプル問題へ簡素化 + テスト追加

### DIFF
--- a/__tests__/puzzles.lvl1.pair.test.ts
+++ b/__tests__/puzzles.lvl1.pair.test.ts
@@ -1,0 +1,29 @@
+import puzzlesData from '../data/puzzles.json';
+
+describe('Lv1-4 Pair puzzle', () => {
+  it('uses non-generic Pair (no Pair<...>)', () => {
+    const level1 = puzzlesData.levels.find((lvl) => lvl.level === 1);
+    if (!level1) throw new Error('Level 1 not found');
+    const target = level1.puzzles[3];
+    const code: string = target.code;
+    const genericPattern = /Pair\s*<[^>]*>/;
+    expect(genericPattern.test(code)).toBe(false);
+  });
+
+  it('contains const pair: Pair = [1, 2];', () => {
+    const level1 = puzzlesData.levels.find((lvl) => lvl.level === 1);
+    if (!level1) throw new Error('Level 1 not found');
+    const target = level1.puzzles[3];
+    const code: string = target.code;
+    expect(code).toContain('const pair: Pair = [1, 2];');
+  });
+
+  it('explanation mentions 両方がnumber型', () => {
+    const level1 = puzzlesData.levels.find((lvl) => lvl.level === 1);
+    if (!level1) throw new Error('Level 1 not found');
+    const target = level1.puzzles[3];
+    const explanation: string = target.explanation;
+    expect(explanation).toContain('両方がnumber型');
+  });
+});
+

--- a/data/puzzles.json
+++ b/data/puzzles.json
@@ -16,8 +16,8 @@
           "explanation": "greetは文字列を返す関数型を指定します。"
         },
         {
-          "code": "type Pair<T> = ???;\nconst pair: Pair<number> = [1, 2];",
-          "explanation": "ジェネリック型Pairは同種の2要素のタプルを表します。"
+          "code": "type Pair = ???;\nconst pair: Pair = [1, 2];",
+          "explanation": "型Pairは、要素数が2つで両方がnumber型であるタプルを表します。"
         },
         {
           "code": "interface Animal { name: string }\ninterface Dog extends ??? { bark(): void }",


### PR DESCRIPTION
# [type-puzzle] <タイトル>

## 概要（日本語）

このPRでは、以下の対応を行いました：

- 機能や型定義の目的を簡潔に記述
- 例: 型チェックボタンの処理を関数分離／設定ファイルをCodex用に出力 など

---

## QA確認したこと（ローカルでの確認）

- [ ] 型エラーが発生しないこと（VSCode上で確認）
- [ ] `package.json` に必要な依存が追加されていること
- [ ] 出力された設定ファイル（例: `.eslintrc.js`, `tsconfig.json`）が意図通りであること
- [ ] **ビルド・テストは実行していません（Codex制約上）**

---

## レビューアーに確認して欲しいこと

- [ ] 型定義の設計が妥当か（過剰なジェネリクスや冗長な型でないか）
- [ ] 不要なコード・依存が含まれていないか
- [ ] コード品質（関数の粒度、コメント、再利用性）
- [ ] Codexの制約に従っているか（`npm install`や外部アクセスが含まれていない）

---

## その他（Codexへの補足：自動生成系）

- 実行不可能な処理（`npx`, `next build`, `vitest`）は含まれていません
- 設定ファイルの出力や関数レベルのロジックのみを含んでいます
- 外部APIアクセス、実行依存のあるコードは避けています
