### PR TITLE
[type-puzzle] Lv1-4: Pair を number タプル問題へ簡素化

### DIFF
--- a/__tests__/puzzles.lvl1.pair.test.ts
+++ b/__tests__/puzzles.lvl1.pair.test.ts
@@ -1,0 +1,29 @@
+import dataJson from '../data/puzzles.json';
+
+type Puzzle = { code: string; explanation: string };
+type Level = { level: number; puzzles: Puzzle[] };
+type PuzzlesData = { levels: Level[] };
+
+describe('Lv1-4 Pair puzzle', () => {
+  const data = dataJson as unknown as PuzzlesData;
+  const level1 = data.levels.find((l) => l.level === 1);
+
+  it('uses non-generic Pair (no Pair<...>)', () => {
+    if (!level1) throw new Error('Level 1 not found');
+    const target = level1.puzzles[3];
+    expect(target.code.includes('Pair<')).toBe(false);
+  });
+
+  it('contains "const pair: Pair = [1, 2];"', () => {
+    if (!level1) throw new Error('Level 1 not found');
+    const target = level1.puzzles[3];
+    expect(target.code.includes('const pair: Pair = [1, 2];')).toBe(true);
+  });
+
+  it('explanation mentions both are number type', () => {
+    if (!level1) throw new Error('Level 1 not found');
+    const target = level1.puzzles[3];
+    expect(target.explanation.includes('両方がnumber型')).toBe(true);
+  });
+});
+

--- a/data/puzzles.json
+++ b/data/puzzles.json
@@ -16,8 +16,8 @@
           "explanation": "greetは文字列を返す関数型を指定します。"
         },
         {
-          "code": "type Pair<T> = ???;\nconst pair: Pair<number> = [1, 2];",
-          "explanation": "ジェネリック型Pairは同種の2要素のタプルを表します。"
+          "code": "type Pair = ???;\nconst pair: Pair = [1, 2];",
+          "explanation": "型Pairは、要素数が2つで両方がnumber型であるタプルを表します。"
         },
         {
           "code": "interface Animal { name: string }\ninterface Dog extends ??? { bark(): void }",


### PR DESCRIPTION
## 概要
- Lv1-4 の出題をジェネリック `Pair<T>` から、非ジェネリックの number タプル `Pair` へ簡素化しました。
- 回帰防止のため、該当出題のテストを追加しました。

## 変更内容
- data/puzzles.json
  - Lv1（level: 1）の puzzles[3] を以下へ差し替え
    - code: `type Pair = ???;\nconst pair: Pair = [1, 2];`
    - explanation: 「型Pairは、要素数が2つで両方がnumber型であるタプルを表します。」
- __tests__/puzzles.lvl1.pair.test.ts
  - `Pair<...>` を含まないことを検証
  - `const pair: Pair = [1, 2];` を含むことを検証
  - 説明文に「両方がnumber型」を含むことを検証

## 動作確認
- ローカルでは Node バージョン要件により yarn コマンドの実行をスキップしました（CIで検証される想定）。
- 文字列データの変更のみのため、画面表示ロジックへの影響は限定的です。

## 関連Issue
- Closes #48

## 実装時間
- 約20分

## チェックリスト
- [x] `data/puzzles.json` の Lv1-4 が非ジェネリックの Pair 出題になっている
- [x] `__tests__/puzzles.lvl1.pair.test.ts` を追加し、要件を検証
- [x] ESLint/TS のエラーを生まないコードパターンに準拠（プロジェクト設定準拠）
- [x] 既存ページ（TOP/PLAY/RESULT）の出題表示に影響しない（データの置換のみ）
