### PR TITLE
[type-puzzle] Lv1-4: Pair を number タプル問題へ簡素化

### DIFF
--- a/__tests__/puzzles.lvl1.pair.test.ts
+++ b/__tests__/puzzles.lvl1.pair.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import puzzles from '../data/puzzles.json';
+
+// Lv1-4 specification tests for Pair puzzle
+
+describe('Lv1-4 Pair puzzle spec', () => {
+  it('uses non-generic Pair and correct code snippet', () => {
+    const level1 = puzzles.levels.find((l) => l.level === 1);
+    expect(level1).toBeTruthy();
+    const target = level1!.puzzles[3];
+
+    // Code must not contain generic Pair<...>
+    expect(target.code).not.toMatch(/Pair\s*</);
+
+    // Code must contain the exact snippet
+    expect(target.code).toContain('type Pair = ???;');
+    expect(target.code).toContain('const pair: Pair = [1, 2];');
+  });
+
+  it('has explanation mentioning both are number type', () => {
+    const level1 = puzzles.levels.find((l) => l.level === 1);
+    const target = level1!.puzzles[3];
+
+    expect(target.explanation).toMatch(/両方がnumber型/);
+  });
+});

--- a/data/puzzles.json
+++ b/data/puzzles.json
@@ -16,8 +16,8 @@
           "explanation": "greetは文字列を返す関数型を指定します。"
         },
         {
-          "code": "type Pair<T> = ???;\nconst pair: Pair<number> = [1, 2];",
-          "explanation": "ジェネリック型Pairは同種の2要素のタプルを表します。"
+          "code": "type Pair = ???;\nconst pair: Pair = [1, 2];",
+          "explanation": "型Pairは、要素数が2つで両方がnumber型であるタプルを表します。"
         },
         {
           "code": "interface Animal { name: string }\ninterface Dog extends ??? { bark(): void }",

--- a/e2e/test-answers.ts
+++ b/e2e/test-answers.ts
@@ -4,7 +4,7 @@ export const ANSWERS = {
     'type User = { name: string; age: number };\nconst u: User = { name: "Taro", age: 20 };',
     'type Point = { x: number; y: number };\nconst p: Point = { x: 1, y: 2 };',
     'const greet: (name: string) => string = (name: string) => `Hello, ${name}`;',
-    'type Pair<T> = [T, T];\nconst pair: Pair<number> = [1, 2];',
+    'type Pair = [number, number];\nconst pair: Pair = [1, 2];',
     'interface Animal { name: string }\ninterface Dog extends Animal { bark(): void }',
   ],
   level2: [


### PR DESCRIPTION
## Summary
- Lv1-4 の出題を非ジェネリック版 Pair に変更
- E2E 用回答データを更新
- 仕様担保のための単体テストを追加

## Details
- data/puzzles.json の Lv1-4 を以下へ変更
  - code: `type Pair = ???;\nconst pair: Pair = [1, 2];`
  - explanation: 「型Pairは、要素数が2つで両方がnumber型であるタプルを表します。」
- e2e/test-answers.ts の Lv1-4 回答を非ジェネリックへ更新
- __tests__/puzzles.lvl1.pair.test.ts を追加
  - `Pair<...>` を含まないこと
  - `const pair: Pair = [1, 2];` を含むこと
  - 説明文に「両方がnumber型」を含むこと

## Acceptance Criteria
- data/puzzles.json の Lv1-4 が非ジェネリックの Pair 出題
- 単体テストが仕様どおり成立
- e2e/test-answers.ts の Lv1-4 が非ジェネリック版
- Lint/TS エラーなし
- 既存ページの表示・回遊に影響なし

## Time Spent
- 着手から PR 作成まで: 約 15 分

## Related Issue
- closes #49